### PR TITLE
repository/paintの実装

### DIFF
--- a/model/paint.go
+++ b/model/paint.go
@@ -1,10 +1,62 @@
 package model
 
-type CountPostByPrefectureID struct {
-	PrefectureId int
+
+const (
+	// 都道府県の ID を定義
+	Hokkaido    PrefectureId = 1
+	Aomori      PrefectureId = 2
+	Iwate       PrefectureId = 3
+	Miyagi      PrefectureId = 4
+	Akita       PrefectureId = 5
+	Yamagata    PrefectureId = 6
+	Fukushima   PrefectureId = 7
+	Ibaraki     PrefectureId = 8
+	Tochigi     PrefectureId = 9
+	Gunma       PrefectureId = 10
+	Saitama     PrefectureId = 11
+	Chiba       PrefectureId = 12
+	Tokyo       PrefectureId = 13
+	Kanagawa    PrefectureId = 14
+	Niigata     PrefectureId = 15
+	Toyama      PrefectureId = 16
+	Ishikawa    PrefectureId = 17
+	Fukui       PrefectureId = 18
+	Yamanashi   PrefectureId = 19
+	Nagano      PrefectureId = 20
+	Gifu        PrefectureId = 21
+	Shizuoka    PrefectureId = 22
+	Aichi       PrefectureId = 23
+	Mie         PrefectureId = 24
+	Shiga       PrefectureId = 25
+	Kyoto       PrefectureId = 26
+	Osaka       PrefectureId = 27
+	Hyogo       PrefectureId = 28
+	Nara        PrefectureId = 29
+	Wakayama    PrefectureId = 30
+	Tottori     PrefectureId = 31
+	Shimane     PrefectureId = 32
+	Okayama     PrefectureId = 33
+	Hiroshima   PrefectureId = 34
+	Yamaguchi   PrefectureId = 35
+	Tokushima   PrefectureId = 36
+	Kagawa      PrefectureId = 37
+	Ehime       PrefectureId = 38
+	Kochi       PrefectureId = 39
+	Fukuoka     PrefectureId = 40
+	Saga        PrefectureId = 41
+	Nagasaki    PrefectureId = 42
+	Kumamoto    PrefectureId = 43
+	Oita        PrefectureId = 44
+	Miyazaki    PrefectureId = 45
+	Kagoshima   PrefectureId = 46
+	Okinawa     PrefectureId = 47
+)
+
+type CountPostByPrefectureId struct {
+	PrefectureId PrefectureId
 	PostCount    int
 }
 
 type Count struct {
-	Data []CountPostByPrefectureID
+	Data []CountPostByPrefectureId
 }

--- a/model/paint.go
+++ b/model/paint.go
@@ -1,0 +1,10 @@
+package model
+
+type CountByPrefectureID struct {
+	PrefectureId int
+	PostCount    int
+}
+
+type Count struct {
+	Data []CountByPrefectureID
+}

--- a/model/paint.go
+++ b/model/paint.go
@@ -1,10 +1,10 @@
 package model
 
-type CountByPrefectureID struct {
+type CountPostByPrefectureID struct {
 	PrefectureId int
 	PostCount    int
 }
 
 type Count struct {
-	Data []CountByPrefectureID
+	Data []CountPostByPrefectureID
 }

--- a/repository/paint/paint.go
+++ b/repository/paint/paint.go
@@ -1,0 +1,1 @@
+package paint

--- a/repository/paint/postgresql/postgresql.go
+++ b/repository/paint/postgresql/postgresql.go
@@ -1,0 +1,1 @@
+package postgresql

--- a/repository/paint/postgresql/postgresql.go
+++ b/repository/paint/postgresql/postgresql.go
@@ -34,7 +34,7 @@ func (q *PaintRepositoryImpl) CountPostsByPrefecture(groupId model.GroupId) (*mo
 	counts := model.Count{}
 
 	for rows.Next() {
-		var countByPrefecture model.CountByPrefectureID
+		var countByPrefecture model.CountPostByPrefectureID
 		if err := rows.Scan(&countByPrefecture.PrefectureId, &countByPrefecture.PostCount); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}

--- a/repository/paint/postgresql/postgresql.go
+++ b/repository/paint/postgresql/postgresql.go
@@ -23,7 +23,7 @@ func (q *PaintRepositoryImpl) CountPostsByPrefecture(groupId model.GroupId) (*mo
 		WHERE ps.group_id = $1
 		GROUP BY p.prefecture_id
 		ORDER BY p.prefecture_id
-`
+	`
 
 	rows, err := q.db.Query(query, groupId)
 	if err != nil {
@@ -31,10 +31,12 @@ func (q *PaintRepositoryImpl) CountPostsByPrefecture(groupId model.GroupId) (*mo
 	}
 	defer rows.Close()
 
-	counts := model.Count{}
+	counts := model.Count{
+		Data: make([]model.CountPostByPrefectureId, 0),
+	}
 
 	for rows.Next() {
-		var countByPrefecture model.CountPostByPrefectureID
+		var countByPrefecture model.CountPostByPrefectureId
 		if err := rows.Scan(&countByPrefecture.PrefectureId, &countByPrefecture.PostCount); err != nil {
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
@@ -47,3 +49,4 @@ func (q *PaintRepositoryImpl) CountPostsByPrefecture(groupId model.GroupId) (*mo
 
 	return &counts, nil
 }
+

--- a/repository/paint/postgresql/postgresql.go
+++ b/repository/paint/postgresql/postgresql.go
@@ -1,1 +1,49 @@
 package postgresql
+
+import (
+	"database/sql"
+	"fmt"
+	"painteer/model"
+)
+
+type PaintRepositoryImpl struct {
+	db *sql.DB
+}
+
+func NewPaintRepository(db *sql.DB) *PaintRepositoryImpl {
+	return &PaintRepositoryImpl{db: db}
+}
+
+func (q *PaintRepositoryImpl) CountPostsByPrefecture(groupId model.GroupId) (*model.Count, error) {
+	query := `
+		SELECT p.prefecture_id, COUNT(p.id) AS post_count
+		FROM posts p
+		INNER JOIN public_setting ps
+		ON p.id = ps.post_id
+		WHERE ps.group_id = $1
+		GROUP BY p.prefecture_id
+		ORDER BY p.prefecture_id
+`
+
+	rows, err := q.db.Query(query, groupId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count posts by prefecture for group_id %v: %w", groupId, err)
+	}
+	defer rows.Close()
+
+	counts := model.Count{}
+
+	for rows.Next() {
+		var countByPrefecture model.CountByPrefectureID
+		if err := rows.Scan(&countByPrefecture.PrefectureId, &countByPrefecture.PostCount); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		counts.Data = append(counts.Data, countByPrefecture)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows iteration error: %w", err)
+	}
+
+	return &counts, nil
+}

--- a/repository/paint/postgresql/postgresql_test.go
+++ b/repository/paint/postgresql/postgresql_test.go
@@ -55,7 +55,7 @@ func TestCreateUserAndPostAndFetchPostCount(t *testing.T) {
 
 	userRepository := userPostgresql.NewAuthRepository(db)
 	postRepository := postPostgresql.NewPostRepository(db)
-	pantRepository := paintPostgresql.NewPaintRepository(db)
+	paintRepository := paintPostgresql.NewPaintRepository(db)
 
 	for _, tc := range testCases {
 		tc := tc
@@ -64,7 +64,7 @@ func TestCreateUserAndPostAndFetchPostCount(t *testing.T) {
 			_, createdPost := testUtils.CreateUserAndPostForTest(t, userRepository, postRepository, tc.createUser, tc.uploadPost)
 
 			// 投稿数を取得
-			count, err := pantRepository.CountPostsByPrefecture(createdPost.GroupId)
+			count, err := paintRepository.CountPostsByPrefecture(createdPost.GroupId)
 			if err != nil {
 				t.Fatalf("CountPostsByPrefecture() error = %v", err)
 			}

--- a/repository/paint/postgresql/postgresql_test.go
+++ b/repository/paint/postgresql/postgresql_test.go
@@ -1,1 +1,104 @@
 package postgresql_test
+
+import (
+	"painteer/model"
+	userPostgresql "painteer/repository/auth/postgresql"
+	postPostgresql "painteer/repository/posting/postgresql"
+	paintPostgresql "painteer/repository/paint/postgresql"
+	setupDB "painteer/repository/utils"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	_ "github.com/lib/pq"
+)
+
+func createUserAndPostForTest(
+	t *testing.T,
+	userRepository *userPostgresql.AuthRepositoryImpl,
+	postRepository *postPostgresql.PostRepositoryImpl,
+	createUser model.CreateUser,
+	uploadPost model.UploadPost,
+) (*model.User, *model.Post) {
+	t.Helper()
+	createdUser, err := userRepository.CreateUser(createUser)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if createdUser == nil {
+		t.Fatal("CreateUser() returned nil, expected valid User")
+	}
+	t.Logf("Created User: %+v", createdUser)
+
+	uploadPost.UserId = createdUser.UserId
+	createdPost, err := postRepository.CreatePost(uploadPost)
+	if err != nil {
+		t.Fatalf("CreatePost() error = %v", err)
+	}
+	t.Logf("Created Post: %+v", createdPost)
+
+	return createdUser, createdPost
+}
+
+func TestCreateUserAndPostAndFetchPostCount(t *testing.T) {
+	testCases := []struct {
+		name       string
+		createUser model.CreateUser
+		uploadPost model.UploadPost
+		want       model.Count
+	}{
+		{
+			name: "ユーザーの作成＆画像の投稿",
+			createUser: model.CreateUser{
+				UserName: "hoge",
+				Icon:     "hoge",
+				AuthId:   "hogehogehogehoge",
+			},
+			uploadPost: model.UploadPost{
+				Image:        "hoge",
+				Date:         time.Date(2025, time.January, 30, 15, 4, 5, 0, time.UTC),
+				Comment:      "hogehoge",
+				PrefectureId: 1,
+				Longitude:    123.456,
+				Latitude:     123.456,
+			},
+			want: model.Count{
+				Data: []model.CountByPrefectureID{
+					{
+						PrefectureId: 1,
+						PostCount:    1,
+					},
+				},
+			},
+		},
+	}
+
+	db, err := setupDB.ConnectDB()
+	if err != nil {
+		t.Fatalf("Failed to connect to the database: %v", err)
+	}
+	defer db.Close()
+
+	userRepository := userPostgresql.NewAuthRepository(db)
+	postRepository := postPostgresql.NewPostRepository(db)
+	pantRepository := paintPostgresql.NewPaintRepository(db)
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// ユーザーと投稿の作成
+			_, createdPost := createUserAndPostForTest(t, userRepository, postRepository, tc.createUser, tc.uploadPost)
+
+			// 投稿数を取得
+			count, err := pantRepository.CountPostsByPrefecture(createdPost.GroupId)
+			if err != nil {
+				t.Fatalf("CountPostsByPrefecture() error = %v", err)
+			}
+
+			// 結果を比較
+			if diff := cmp.Diff(tc.want, *count); diff != "" {
+				t.Errorf("CountPostsByPrefecture() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/repository/paint/postgresql/postgresql_test.go
+++ b/repository/paint/postgresql/postgresql_test.go
@@ -1,0 +1,1 @@
+package postgresql_test

--- a/repository/testUtils/testUtils.go
+++ b/repository/testUtils/testUtils.go
@@ -1,0 +1,35 @@
+package testUtils
+
+import (
+	"painteer/model"
+	userPostgresql "painteer/repository/auth/postgresql"
+	postPostgresql "painteer/repository/posting/postgresql"
+	"testing"
+)
+
+func CreateUserAndPostForTest(
+	t *testing.T,
+	userRepository *userPostgresql.AuthRepositoryImpl,
+	postRepository *postPostgresql.PostRepositoryImpl,
+	createUser model.CreateUser,
+	uploadPost model.UploadPost,
+) (*model.User, *model.Post) {
+	t.Helper()
+	createdUser, err := userRepository.CreateUser(createUser)
+	if err != nil {
+		t.Fatalf("CreateUser() error = %v", err)
+	}
+	if createdUser == nil {
+		t.Fatal("CreateUser() returned nil, expected valid User")
+	}
+	t.Logf("Created User: %+v", createdUser)
+
+	uploadPost.UserId = createdUser.UserId
+	createdPost, err := postRepository.CreatePost(uploadPost)
+	if err != nil {
+		t.Fatalf("CreatePost() error = %v", err)
+	}
+	t.Logf("Created Post: %+v", createdPost)
+
+	return createdUser, createdPost
+}


### PR DESCRIPTION
postをDBからprefectureIdついてる数で数えるメソッドが必要なんですけど，
prefectureIdを引数として1個のメソッドとするか，全部一気に取ってくるメソッドにするか悩んでます．
prefectureIdを引数として1個のメソッドとする -> 後に一個だけとりたい時便利かも．でもfor文で回すってなったら処理時間長い？
一気に取ってくる -> こっちの方が処理早いかもだけど，汎用性がないし，sql複雑で処理がみにくい？